### PR TITLE
JW-1001: remove conflicting if_nametoindex definition

### DIFF
--- a/net/if.h
+++ b/net/if.h
@@ -44,6 +44,5 @@ struct if_nameindex
 	char *if_name;		/* null terminated name: "eth0", ... */
 };
 
-unsigned int if_nametoindex(const char *ifname);
 struct if_nameindex *if_nameindex(void);
 void if_freenameindex(struct if_nameindex *ptr);


### PR DESCRIPTION
* `if_nametoindex` definition confilcts with definition found in Windows headers (https://msdn.microsoft.com/en-us/library/windows/desktop/bb408409(v=vs.85).aspx)