### PR TITLE
JW-914: add ETH_HLEN used in agent tests

### DIFF
--- a/netinet/if_ether.h
+++ b/netinet/if_ether.h
@@ -46,6 +46,8 @@ typedef struct	ether_header {
 	u_short	ether_type;
 } ETHERHDR;
 
+#define ETH_HLEN            (14)
+
 #define	ETHERTYPE_PUP		0x0200	/* PUP protocol */
 #define	ETHERTYPE_IP		0x0800	/* IP protocol */
 #define ETHERTYPE_ARP		0x0806	/* Addr. resolution protocol */


### PR DESCRIPTION
Related PR: https://github.com/codilime/contrail-controller/pull/56
Test list: https://gist.github.com/sodar/658e8a14d8bd1495c33352a59e105ec0

`ETH_HLEN` is used `agent_test_xml.lib` which is linked with `test_oper_xml.exe` test.